### PR TITLE
Changes to make store_clicks.jl work

### DIFF
--- a/dash_docs/chapters/dash_core_components/Store/examples/store_clicks.jl
+++ b/dash_docs/chapters/dash_core_components/Store/examples/store_clicks.jl
@@ -12,7 +12,7 @@ app.layout = html_div([
     # The local store will take the initial data
     # only the first time the page is loaded
     # and keep it until it is cleared.
-    # dcc_store(id="local", storage_type="local"),
+    dcc_store(id="local", storage_type="local"),
     # Same as the local store but will lose the data
     # when the browser/tab closes.
     dcc_store(id="session", storage_type="session"),
@@ -59,7 +59,7 @@ for store in ("memory", "local", "session")
     end
     data = (;data...,clicks = data[Symbol("clicks")]+1)
     return data
-  end 
+  end
 
   #  # output the stored clicks in the table cell.
   callback!(app, Output(string(store, "-clicks"), "children"),
@@ -74,14 +74,14 @@ for store in ("memory", "local", "session")
     if ts isa Nothing
       throw(PreventUpdate())
     end
-    
+
     data = (typeof(data) == Nothing) ? NamedTuple() : data
     if haskey(data, Symbol("clicks"))
       return data[Symbol("clicks")]
     else
       return 0
     end
-  end   
+  end
 end
 
 

--- a/dash_docs/chapters/sharing_data/examples/scoping.jl
+++ b/dash_docs/chapters/sharing_data/examples/scoping.jl
@@ -3,7 +3,6 @@ using Dash, DashHtmlComponents, DashCoreComponents, DataFrames
 df8 = DataFrame(a = [1, 2, 3],
                b = [4, 1, 4],
                c = ["x", "y", "z"])
-s
 app = dash()
 
 app.layout = html_div() do


### PR DESCRIPTION
I made minimal changes to `ParseExampleExpr` to make loops and etc work from the examples. It seems to work, but this is a temporary solution. If there is no move to another generation engine, then everything needs to be thoroughly rewritten